### PR TITLE
Adds tablet mode, without tablet presenter

### DIFF
--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.java
@@ -141,7 +141,15 @@ public class TasksScreenTest {
         onView(withText(TITLE1)).perform(click());
 
         // Click on the edit task button
-        onView(withId(R.id.fab_edit_task)).perform(click());
+        if (mTasksActivityTestRule.getActivity()
+                .getSupportFragmentManager().findFragmentById(R.id.contentFrame_detail) == null) {
+            // On phone click on FAB
+            onView(withId(R.id.fab_edit_task)).perform(click());
+        } else {
+            // On tablet, click on menu item
+            onView(withId(R.id.menu_edit)).perform(click());
+        }
+
 
         String editTaskTitle = TITLE2;
         String editTaskDescription = "New Description";

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.java
@@ -174,7 +174,10 @@ public class TasksRepository implements TasksDataSource {
     @Override
     public void activateTask(@NonNull String taskId) {
         checkNotNull(taskId);
-        activateTask(getTaskWithId(taskId));
+        Task taskWithId = getTaskWithId(taskId);
+        if (taskWithId != null) {
+            activateTask(taskWithId);
+        }
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.java
@@ -23,9 +23,8 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
-import com.example.android.architecture.blueprints.todoapp.Injection;
 import com.example.android.architecture.blueprints.todoapp.R;
-import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
+import com.example.android.architecture.blueprints.todoapp.tasks.TasksMvpController;
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource;
 
 /**
@@ -51,21 +50,7 @@ public class TaskDetailActivity extends AppCompatActivity {
         // Get the requested task id
         String taskId = getIntent().getStringExtra(EXTRA_TASK_ID);
 
-        TaskDetailFragment taskDetailFragment = (TaskDetailFragment) getSupportFragmentManager()
-                .findFragmentById(R.id.contentFrame);
-
-        if (taskDetailFragment == null) {
-            taskDetailFragment = TaskDetailFragment.newInstance(taskId);
-
-            ActivityUtils.addFragmentToActivity(getSupportFragmentManager(),
-                    taskDetailFragment, R.id.contentFrame);
-        }
-
-        // Create the presenter
-        new TaskDetailPresenter(
-                taskId,
-                Injection.provideTasksRepository(getApplicationContext()),
-                taskDetailFragment);
+        TasksMvpController.createTaskDetailView(this, taskId);
     }
 
     @Override

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.java
@@ -77,6 +77,8 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
                              Bundle savedInstanceState) {
         View root = inflater.inflate(R.layout.taskdetail_frag, container, false);
         setHasOptionsMenu(true);
+        // TODO: why are we retaining
+        setRetainInstance(true);
         mDetailTitle = (TextView) root.findViewById(R.id.task_detail_title);
         mDetailDescription = (TextView) root.findViewById(R.id.task_detail_description);
         mDetailCompleteStatus = (CheckBox) root.findViewById(R.id.task_detail_complete);
@@ -84,13 +86,14 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
         // Set up floating action button
         FloatingActionButton fab =
                 (FloatingActionButton) getActivity().findViewById(R.id.fab_edit_task);
-
-        fab.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                mPresenter.editTask();
-            }
-        });
+        if (fab != null) { // Fab is null in tablet mode
+            fab.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mPresenter.editTask();
+                }
+            });
+        }
 
         return root;
     }
@@ -105,6 +108,9 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
         switch (item.getItemId()) {
             case R.id.menu_delete:
                 mPresenter.deleteTask();
+                return true;
+            case R.id.menu_edit: // tablet mode only
+                mPresenter.editTask();
                 return true;
         }
         return false;
@@ -164,7 +170,10 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
 
     @Override
     public void showTaskDeleted() {
-        getActivity().finish();
+        // Close the activity if not in tablet mode.
+        if (getFragmentManager().findFragmentById(R.id.contentFrame_detail) == null) {
+            getActivity().finish();
+        }
     }
 
     public void showTaskMarkedComplete() {
@@ -183,7 +192,9 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
         if (requestCode == REQUEST_EDIT_TASK) {
             // If the task was edited successfully, go back to the list.
             if (resultCode == Activity.RESULT_OK) {
-                getActivity().finish();
+                if (getFragmentManager().findFragmentById(R.id.contentFrame_detail) == null) {
+                    getActivity().finish();
+                }
             }
         }
     }
@@ -196,12 +207,16 @@ public class TaskDetailFragment extends Fragment implements TaskDetailContract.V
 
     @Override
     public void showMissingTask() {
-        mDetailTitle.setText("");
+        mDetailTitle.setText(getString(R.string.no_data));
         mDetailDescription.setText(getString(R.string.no_data));
     }
 
     @Override
     public boolean isActive() {
         return isAdded();
+    }
+
+    public TaskDetailContract.Presenter getPresenter() {
+        return mPresenter;
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksActivity.java
@@ -28,10 +28,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 
-import com.example.android.architecture.blueprints.todoapp.Injection;
 import com.example.android.architecture.blueprints.todoapp.R;
 import com.example.android.architecture.blueprints.todoapp.statistics.StatisticsActivity;
-import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource;
 
 public class TasksActivity extends AppCompatActivity {
@@ -40,7 +38,7 @@ public class TasksActivity extends AppCompatActivity {
 
     private DrawerLayout mDrawerLayout;
 
-    private TasksPresenter mTasksPresenter;
+    private TasksContract.Presenter mTasksPresenter;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -62,18 +60,10 @@ public class TasksActivity extends AppCompatActivity {
             setupDrawerContent(navigationView);
         }
 
-        TasksFragment tasksFragment =
-                (TasksFragment) getSupportFragmentManager().findFragmentById(R.id.contentFrame);
-        if (tasksFragment == null) {
-            // Create the fragment
-            tasksFragment = TasksFragment.newInstance();
-            ActivityUtils.addFragmentToActivity(
-                    getSupportFragmentManager(), tasksFragment, R.id.contentFrame);
-        }
+        // Create a TasksMvpController every time, even after rotation.
+        TasksMvpController tasksMvpController = TasksMvpController.createTasksView(this);
 
-        // Create the presenter
-        mTasksPresenter = new TasksPresenter(
-                Injection.provideTasksRepository(getApplicationContext()), tasksFragment);
+        mTasksPresenter = tasksMvpController.getTasksPresenter();
 
         // Load previously saved state, if available.
         if (savedInstanceState != null) {
@@ -98,7 +88,7 @@ public class TasksActivity extends AppCompatActivity {
                 mDrawerLayout.openDrawer(GravityCompat.START);
                 return true;
         }
-        return super.onOptionsItemSelected(item);
+        return false;
     }
 
     private void setupDrawerContent(NavigationView navigationView) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.java
@@ -16,6 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -46,8 +48,6 @@ import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetail
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Display a grid of {@link Task}s. User can choose to view all, active or completed tasks.
@@ -172,7 +172,7 @@ public class TasksFragment extends Fragment implements TasksContract.View {
                 mPresenter.loadTasks(true);
                 break;
         }
-        return true;
+        return false;
     }
 
     @Override
@@ -266,7 +266,7 @@ public class TasksFragment extends Fragment implements TasksContract.View {
         showNoTasksViews(
                 getResources().getString(R.string.no_tasks_all),
                 R.drawable.ic_assignment_turned_in_24dp,
-                false
+                true
         );
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksMvpController.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksMvpController.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2016, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.architecture.blueprints.todoapp.tasks;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+
+import com.example.android.architecture.blueprints.todoapp.Injection;
+import com.example.android.architecture.blueprints.todoapp.R;
+import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailFragment;
+import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailPresenter;
+import com.example.android.architecture.blueprints.todoapp.util.ActivityUtils;
+
+/**
+ * Class that creates fragments (MVP views) and makes the necessary connections between them.
+ */
+public class TasksMvpController {
+
+    private final FragmentActivity mFragmentActivity;
+
+    private TasksPresenter mTasksPresenter;
+
+    private TaskDetailPresenter mTaskDetailPresenter;
+
+    /**
+     * Creates a controller for a task view for phones or tablets.
+     * @param fragmentActivity the context activity
+     * @return a TasksMvpController
+     */
+    public static TasksMvpController createTasksView(@NonNull FragmentActivity fragmentActivity) {
+        checkNotNull(fragmentActivity);
+        TasksMvpController tasksMvpController = new TasksMvpController(fragmentActivity);
+        tasksMvpController.initTasksView();
+        return tasksMvpController;
+    }
+
+    /**
+     * Creates a controller for a task detail view for phones or tablets.
+     * @param fragmentActivity the context activity
+     * @return a TasksMvpController
+     */
+    public static TasksMvpController createTaskDetailView(
+            @NonNull FragmentActivity fragmentActivity, String taskId) {
+        checkNotNull(fragmentActivity);
+        TasksMvpController tasksMvpController = new TasksMvpController(fragmentActivity);
+        tasksMvpController.initTaskDetailView(taskId);
+        return tasksMvpController;
+    }
+
+    // Force factory method, prevent direct instantiation:
+    private TasksMvpController(@NonNull FragmentActivity fragmentActivity) {
+        mFragmentActivity = fragmentActivity;
+    }
+
+    private void initTasksView() {
+        if (isTablet()) {
+            createTabletElements();
+        } else {
+            TasksFragment tasksFragment = findOrCreateTasksFragment();
+            mTasksPresenter = createListPresenter(tasksFragment);
+            tasksFragment.setPresenter(mTasksPresenter);
+        }
+    }
+
+    private void initTaskDetailView(String taskId) {
+        TaskDetailFragment taskDetailFragment = findOrCreateTaskDetailFragment(taskId);
+        mTaskDetailPresenter = createTaskDetailPresenter(taskId, taskDetailFragment);
+        taskDetailFragment.setPresenter(mTaskDetailPresenter);
+    }
+
+    public TasksPresenter getTasksPresenter() {
+        return mTasksPresenter;
+    }
+
+    public TaskDetailPresenter getTaskDetailPresenter() {
+        return mTaskDetailPresenter;
+    }
+
+    /**
+     * To be called in tablet mode when a new detail view is requested.
+     * @param taskId the ID of the task
+     * @return the fragment to be added to the UI
+     */
+    public TaskDetailFragment createDetailViewForTablet(String taskId) {
+        // Create the View
+        TaskDetailFragment taskDetailFragment = TaskDetailFragment.newInstance(taskId);
+
+        // Create the Presenter
+        mTaskDetailPresenter = createTaskDetailPresenter(taskId,
+                taskDetailFragment);
+
+        // Wire presenters
+        taskDetailFragment.setPresenter(mTaskDetailPresenter);
+        mTasksPresenter.setTaskDetailPresenter(mTaskDetailPresenter);
+        mTaskDetailPresenter.setTasksPresenter(mTasksPresenter);
+
+        return taskDetailFragment;
+    }
+
+    private void createTabletElements() {
+        TasksFragment tasksFragment;// Tablet presenter rule all presenters
+
+        tasksFragment = findOrCreateTasksFragment();
+        mTasksPresenter = createListPresenter(tasksFragment);
+
+        tasksFragment.setPresenter(mTasksPresenter);
+
+        // TaskDetailFragment is retained, so let's reuse its presenter.
+        TaskDetailFragment taskDetailFragment = getDetailFragment();
+        if (taskDetailFragment != null && taskDetailFragment.isAdded()) {
+                mTaskDetailPresenter =
+                        (TaskDetailPresenter) taskDetailFragment.getPresenter();
+
+                mTasksPresenter.setTaskDetailPresenter(mTaskDetailPresenter);
+                mTaskDetailPresenter.setTasksPresenter(mTasksPresenter);
+        }
+    }
+
+    @NonNull
+    private TaskDetailPresenter createTaskDetailPresenter(
+            String taskId, TaskDetailFragment taskDetailFragment) {
+        return new TaskDetailPresenter(
+                taskId,
+                Injection.provideTasksRepository(mFragmentActivity.getApplicationContext()),
+                taskDetailFragment,
+                new TasksNavigator(mFragmentActivity, this));
+    }
+
+    private TasksPresenter createListPresenter(TasksFragment tasksFragment) {
+        mTasksPresenter = new TasksPresenter(
+                Injection.provideTasksRepository(mFragmentActivity.getApplicationContext()),
+                tasksFragment,
+                new TasksNavigator(mFragmentActivity, this));
+
+        return mTasksPresenter;
+    }
+
+    @NonNull
+    private TasksFragment findOrCreateTasksFragment() {
+        TasksFragment tasksFragment =
+                (TasksFragment) getSupportFragmentManager().findFragmentById(R.id.contentFrame);
+        if (tasksFragment == null) {
+            // Create the fragment
+            tasksFragment = TasksFragment.newInstance();
+            ActivityUtils.addFragmentToActivity(
+                    getSupportFragmentManager(), tasksFragment, R.id.contentFrame);
+        }
+        return tasksFragment;
+    }
+
+    @NonNull
+    private TaskDetailFragment findOrCreateTaskDetailFragment(String taskId) {
+        TaskDetailFragment taskDetailFragment =
+                (TaskDetailFragment) getSupportFragmentManager().findFragmentById(R.id.contentFrame);
+        if (taskDetailFragment == null) {
+            // Create the fragment
+            taskDetailFragment = TaskDetailFragment.newInstance(taskId);
+            ActivityUtils.addFragmentToActivity(
+                    getSupportFragmentManager(), taskDetailFragment, R.id.contentFrame);
+        }
+        return taskDetailFragment;
+    }
+
+    private TaskDetailFragment getDetailFragment() {
+        return (TaskDetailFragment) mFragmentActivity.getSupportFragmentManager().findFragmentById(
+                R.id.contentFrame_detail);
+    }
+
+    private FragmentManager getSupportFragmentManager() {
+        return mFragmentActivity.getSupportFragmentManager();
+    }
+
+    private boolean isTablet() {
+        return mFragmentActivity.getResources().getBoolean(R.bool.isTablet);
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksNavigator.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksNavigator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.architecture.blueprints.todoapp.tasks;
+
+import static com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailActivity.EXTRA_TASK_ID;
+
+import android.content.Intent;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentTransaction;
+
+import com.example.android.architecture.blueprints.todoapp.R;
+import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailActivity;
+import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailFragment;
+
+/**
+ * TODO: javadoc
+ */
+
+public class TasksNavigator {
+
+    private final FragmentActivity mFragmentActivity;
+
+    private final TasksMvpController mTasksMvpBuilder;
+
+    public TasksNavigator(FragmentActivity fragmentActivity, TasksMvpController tasksMvpBuilder) {
+        mFragmentActivity = fragmentActivity;
+        mTasksMvpBuilder = tasksMvpBuilder;
+    }
+
+    public void onTaskDeleted() {
+        if (isTablet()) {
+            removeDetailPane();
+        } else {
+            mFragmentActivity.finish();
+        }
+    }
+
+    public void startTaskDetail(String taskId) {
+        if (isTablet()) {
+            TaskDetailFragment detailFragment = mTasksMvpBuilder.createDetailViewForTablet(taskId);
+
+            // Show fragment
+            if (getDetailFragment() == null) { //TODO: better alternative?
+                mFragmentActivity.getSupportFragmentManager().beginTransaction()
+                        .add(R.id.contentFrame_detail, detailFragment)
+                        .addToBackStack(null)
+                        .commit();
+            } else {
+                mFragmentActivity.getSupportFragmentManager().beginTransaction()
+                        .replace(R.id.contentFrame_detail, detailFragment)
+                        .commit();
+            }
+
+        } else {
+            Intent intent = new Intent(mFragmentActivity, TaskDetailActivity.class);
+            intent.putExtra(EXTRA_TASK_ID, taskId);
+            mFragmentActivity.startActivity(intent);
+        }
+    }
+
+    public boolean isTablet() {
+        return mFragmentActivity.getResources().getBoolean(R.bool.isTablet);
+    }
+
+    public void removeDetailPane() {
+        Fragment detailFragment = getDetailFragment();
+        FragmentTransaction transaction = mFragmentActivity.getSupportFragmentManager().beginTransaction();
+        transaction.remove(detailFragment);
+        transaction.commit();
+    }
+
+    private Fragment getDetailFragment() {
+        return mFragmentActivity.getSupportFragmentManager().findFragmentById(R.id.contentFrame_detail);
+    }
+}

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenter.java
@@ -16,19 +16,21 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskActivity;
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
+import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailPresenter;
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Listens to user actions from the UI ({@link TasksFragment}), retrieves the data and updates the
@@ -39,21 +41,32 @@ public class TasksPresenter implements TasksContract.Presenter {
     private final TasksRepository mTasksRepository;
 
     private final TasksContract.View mTasksView;
+    @NonNull
+    private final TasksNavigator mTasksNavigator;
 
     private TasksFilterType mCurrentFiltering = TasksFilterType.ALL_TASKS;
 
     private boolean mFirstLoad = true;
 
-    public TasksPresenter(@NonNull TasksRepository tasksRepository, @NonNull TasksContract.View tasksView) {
+    @Nullable
+    private TaskDetailPresenter mTaskDetailPresenter;
+
+    TasksPresenter(
+            @NonNull TasksRepository tasksRepository,
+            @NonNull TasksContract.View tasksView,
+            @NonNull TasksNavigator tasksNavigator) {
         mTasksRepository = checkNotNull(tasksRepository, "tasksRepository cannot be null");
         mTasksView = checkNotNull(tasksView, "tasksView cannot be null!");
-
-        mTasksView.setPresenter(this);
+        mTasksNavigator = checkNotNull(tasksNavigator);
     }
 
     @Override
     public void start() {
         loadTasks(false);
+    }
+
+    public void setTaskDetailPresenter(@Nullable TaskDetailPresenter presenter) {
+        mTaskDetailPresenter = presenter;
     }
 
     @Override
@@ -190,7 +203,7 @@ public class TasksPresenter implements TasksContract.Presenter {
     @Override
     public void openTaskDetails(@NonNull Task requestedTask) {
         checkNotNull(requestedTask, "requestedTask cannot be null!");
-        mTasksView.showTaskDetailsUi(requestedTask.getId());
+        mTasksNavigator.startTaskDetail(requestedTask.getId());
     }
 
     @Override
@@ -199,6 +212,12 @@ public class TasksPresenter implements TasksContract.Presenter {
         mTasksRepository.completeTask(completedTask);
         mTasksView.showTaskMarkedComplete();
         loadTasks(false, false);
+
+        // In tablet mode, ping the other presenter in case it needs to update
+        if (mTaskDetailPresenter != null
+                && mTaskDetailPresenter.getTaskId().equals(completedTask.getId())) {
+            mTaskDetailPresenter.start();
+        }
     }
 
     @Override
@@ -207,6 +226,11 @@ public class TasksPresenter implements TasksContract.Presenter {
         mTasksRepository.activateTask(activeTask);
         mTasksView.showTaskMarkedActive();
         loadTasks(false, false);
+        // In tablet mode, ping the other presenter in case it needs to update
+        if (mTaskDetailPresenter != null
+                && mTaskDetailPresenter.getTaskId().equals(activeTask.getId())) {
+            mTaskDetailPresenter.start();
+        }
     }
 
     @Override
@@ -214,6 +238,30 @@ public class TasksPresenter implements TasksContract.Presenter {
         mTasksRepository.clearCompletedTasks();
         mTasksView.showCompletedTasksCleared();
         loadTasks(false, false);
+
+        // In tablet mode, ping the other presenter in case it needs to update
+        if (mTaskDetailPresenter != null) {
+
+            // If task on detail has just been cleared, remove fragment.
+            String taskId = mTaskDetailPresenter.getTaskId();
+            if (taskId != null) {
+                mTasksRepository.getTask(taskId,
+                        new TasksDataSource.GetTaskCallback() {
+                            @Override
+                            public void onTaskLoaded(Task task) {
+                                // No-op
+                                if (task == null) {
+                                    mTasksNavigator.onTaskDeleted();
+                                }
+                            }
+
+                            @Override
+                            public void onDataNotAvailable() {
+                                mTasksNavigator.onTaskDeleted();
+                            }
+                        });
+            }
+        }
     }
 
     /**

--- a/todoapp/app/src/main/res/layout-sw660dp/tasks_act.xml
+++ b/todoapp/app/src/main/res/layout-sw660dp/tasks_act.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2015 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TasksActivity"
+    tools:openDrawer="start">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <android.support.design.widget.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/colorPrimary"
+                android:minHeight="?attr/actionBarSize"
+                android:theme="@style/Toolbar"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+        </android.support.design.widget.AppBarLayout>
+
+        <android.support.design.widget.CoordinatorLayout
+            android:id="@+id/coordinatorLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:baselineAligned="false">
+
+                <FrameLayout
+                    android:id="@+id/contentFrame"
+                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent" />
+
+                <FrameLayout
+                    android:id="@+id/contentFrame_detail"
+                    android:layout_weight="2"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent" />
+            </LinearLayout>
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/fab_add_task"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/fab_margin"
+                android:src="@drawable/ic_add"
+                app:fabSize="normal"
+                app:layout_anchor="@id/contentFrame"
+                app:layout_anchorGravity="bottom|right|end" />
+        </android.support.design.widget.CoordinatorLayout>
+
+    </LinearLayout>
+
+    <!-- Navigation Drawer -->
+    <android.support.design.widget.NavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:fitsSystemWindows="true"
+        app:headerLayout="@layout/nav_header"
+        app:menu="@menu/drawer_actions" />
+
+</android.support.v4.widget.DrawerLayout>
+

--- a/todoapp/app/src/main/res/menu-sw660dp/taskdetail_fragment_menu.xml
+++ b/todoapp/app/src/main/res/menu-sw660dp/taskdetail_fragment_menu.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2016, The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_delete"
+        android:title="@string/menu_delete_task"
+        app:showAsAction="always|withText" />
+    <item
+        android:id="@+id/menu_edit"
+        android:title="@string/menu_edit_task"
+        app:showAsAction="always|withText" />
+</menu>

--- a/todoapp/app/src/main/res/values-sw600dp/values.xml
+++ b/todoapp/app/src/main/res/values-sw600dp/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isTablet">true</bool>
+</resources>

--- a/todoapp/app/src/main/res/values/strings.xml
+++ b/todoapp/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
   -->
 
 <resources>
-    <string name="app_name">TO-DO-MVP</string>
+    <string name="app_name">TO-DO-MVP-TABLET</string>
     <string name="add_task">New TO-DO</string>
     <string name="edit_task">Edit TO-DO</string>
     <string name="task_marked_complete">Task marked complete</string>
@@ -25,6 +25,7 @@
     <string name="menu_filter">Filter</string>
     <string name="menu_clear">Clear completed</string>
     <string name="menu_delete_task">Delete task</string>
+    <string name="menu_edit_task">Edit task</string>
     <string name="navigation_view_header_title">TO-DOs</string>
     <string name="title_hint">Title</string>
     <string name="description_hint">Enter your TO-DO here.</string>

--- a/todoapp/app/src/main/res/values/values.xml
+++ b/todoapp/app/src/main/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="isTablet">false</bool>
+</resources>

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenterTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailPresenterTest.java
@@ -16,9 +16,15 @@
 
 package com.example.android.architecture.blueprints.todoapp.taskdetail;
 
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
+import com.example.android.architecture.blueprints.todoapp.tasks.TasksNavigator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,11 +32,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the implementation of {@link TaskDetailPresenter}
@@ -49,6 +50,9 @@ public class TaskDetailPresenterTest {
 
     @Mock
     private TasksRepository mTasksRepository;
+
+    @Mock
+    private TasksNavigator mTasksNavigator;
 
     @Mock
     private TaskDetailContract.View mTaskDetailView;
@@ -76,7 +80,7 @@ public class TaskDetailPresenterTest {
     public void getActiveTaskFromRepositoryAndLoadIntoView() {
         // When tasks presenter is asked to open a task
         mTaskDetailPresenter = new TaskDetailPresenter(
-                ACTIVE_TASK.getId(), mTasksRepository, mTaskDetailView);
+                ACTIVE_TASK.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.start();
 
         // Then task is loaded from model, callback is captured and progress indicator is shown
@@ -97,7 +101,7 @@ public class TaskDetailPresenterTest {
     @Test
     public void getCompletedTaskFromRepositoryAndLoadIntoView() {
         mTaskDetailPresenter = new TaskDetailPresenter(
-                COMPLETED_TASK.getId(), mTasksRepository, mTaskDetailView);
+                COMPLETED_TASK.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.start();
 
         // Then task is loaded from model, callback is captured and progress indicator is shown
@@ -120,7 +124,7 @@ public class TaskDetailPresenterTest {
     public void getUnknownTaskFromRepositoryAndLoadIntoView() {
         // When loading of a task is requested with an invalid task ID.
         mTaskDetailPresenter = new TaskDetailPresenter(
-                INVALID_TASK_ID, mTasksRepository, mTaskDetailView);
+                INVALID_TASK_ID, mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.start();
         verify(mTaskDetailView).showMissingTask();
     }
@@ -132,7 +136,7 @@ public class TaskDetailPresenterTest {
 
         // When the deletion of a task is requested
         mTaskDetailPresenter = new TaskDetailPresenter(
-                task.getId(), mTasksRepository, mTaskDetailView);
+                task.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.deleteTask();
 
         // Then the repository and the view are notified
@@ -145,7 +149,7 @@ public class TaskDetailPresenterTest {
         // Given an initialized presenter with an active task
         Task task = new Task(TITLE_TEST, DESCRIPTION_TEST);
         mTaskDetailPresenter = new TaskDetailPresenter(
-                task.getId(), mTasksRepository, mTaskDetailView);
+                task.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.start();
 
         // When the presenter is asked to complete the task
@@ -161,7 +165,7 @@ public class TaskDetailPresenterTest {
         // Given an initialized presenter with a completed task
         Task task = new Task(TITLE_TEST, DESCRIPTION_TEST, true);
         mTaskDetailPresenter = new TaskDetailPresenter(
-                task.getId(), mTasksRepository, mTaskDetailView);
+                task.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.start();
 
         // When the presenter is asked to activate the task
@@ -176,7 +180,7 @@ public class TaskDetailPresenterTest {
     public void activeTaskIsShownWhenEditing() {
         // When the edit of an ACTIVE_TASK is requested
         mTaskDetailPresenter = new TaskDetailPresenter(
-                ACTIVE_TASK.getId(), mTasksRepository, mTaskDetailView);
+                ACTIVE_TASK.getId(), mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.editTask();
 
         // Then the view is notified
@@ -187,7 +191,7 @@ public class TaskDetailPresenterTest {
     public void invalidTaskIsNotShownWhenEditing() {
         // When the edit of an invalid task id is requested
         mTaskDetailPresenter = new TaskDetailPresenter(
-                INVALID_TASK_ID, mTasksRepository, mTaskDetailView);
+                INVALID_TASK_ID, mTasksRepository, mTaskDetailView, mTasksNavigator);
         mTaskDetailPresenter.editTask();
 
         // Then the edit mode is never started

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenterTest.java
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksPresenterTest.java
@@ -16,6 +16,11 @@
 
 package com.example.android.architecture.blueprints.todoapp.tasks;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.example.android.architecture.blueprints.todoapp.data.Task;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource.LoadTasksCallback;
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository;
@@ -30,11 +35,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 /**
  * Unit tests for the implementation of {@link TasksPresenter}
  */
@@ -44,6 +44,9 @@ public class TasksPresenterTest {
 
     @Mock
     private TasksRepository mTasksRepository;
+
+    @Mock
+    private TasksNavigator mTasksNavigator;
 
     @Mock
     private TasksContract.View mTasksView;
@@ -64,7 +67,7 @@ public class TasksPresenterTest {
         MockitoAnnotations.initMocks(this);
 
         // Get a reference to the class under test
-        mTasksPresenter = new TasksPresenter(mTasksRepository, mTasksView);
+        mTasksPresenter = new TasksPresenter(mTasksRepository, mTasksView, mTasksNavigator);
 
         // The presenter won't update the view unless it's active.
         when(mTasksView.isActive()).thenReturn(true);
@@ -148,7 +151,7 @@ public class TasksPresenterTest {
         mTasksPresenter.openTaskDetails(requestedTask);
 
         // Then task detail UI is shown
-        verify(mTasksView).showTaskDetailsUi(any(String.class));
+        verify(mTasksNavigator).startTaskDetail(any(String.class));
     }
 
     @Test

--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0-alpha6'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This PR is based on todo-mvp. It adds a tablet layout and modifies the TasksPresenter so that it's tablet-aware.

In tablet mode, there are two fragments (views) and two presenters at the same time. Each presenter (list, detail) has a reference to the other. If the reference to the other presenter is null then it's in phone mode.

The connection between fragments and presenters is done in a new class called TasksMvpController which is also tablet-aware.

Pros: tablet mode is easy to understand and follow

Cons: there is a maintenance problem: developers must remember to implement the tablet behavior when adding a new feature. There's no way to enforce writing the tablet behavior. See the Tablet presenter PR to see how to overcome this.

Minor changes:
- There is a navigator class in charge of the user flow. 
