### PR TITLE
 Fixes all initial calls to start() from fragments to viewmodels

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ViewModelFactory.kt
@@ -24,29 +24,26 @@ import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetail
 import com.example.android.architecture.blueprints.todoapp.tasks.TasksViewModel
 
 /**
- * A creator is used to inject the product ID into the ViewModel
- *
- *
- * This creator is to showcase how to inject dependencies into ViewModels. It's not
- * actually necessary in this case, as the product ID can be passed in a public method.
+ * Factory for all ViewModels.
  */
+@Suppress("UNCHECKED_CAST")
 class ViewModelFactory constructor(
         private val tasksRepository: TasksRepository
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>) =
-            with(modelClass) {
-                when {
-                    isAssignableFrom(StatisticsViewModel::class.java) ->
-                        StatisticsViewModel(tasksRepository)
-                    isAssignableFrom(TaskDetailViewModel::class.java) ->
-                        TaskDetailViewModel(tasksRepository)
-                    isAssignableFrom(AddEditTaskViewModel::class.java) ->
-                        AddEditTaskViewModel(tasksRepository)
-                    isAssignableFrom(TasksViewModel::class.java) ->
-                        TasksViewModel(tasksRepository)
-                    else ->
-                        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
-                }
-            } as T
+        with(modelClass) {
+            when {
+                isAssignableFrom(StatisticsViewModel::class.java) ->
+                    StatisticsViewModel(tasksRepository)
+                isAssignableFrom(TaskDetailViewModel::class.java) ->
+                    TaskDetailViewModel(tasksRepository)
+                isAssignableFrom(AddEditTaskViewModel::class.java) ->
+                    AddEditTaskViewModel(tasksRepository)
+                isAssignableFrom(TasksViewModel::class.java) ->
+                    TasksViewModel(tasksRepository)
+                else ->
+                    throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+            }
+        } as T
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
@@ -22,6 +22,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.android.architecture.blueprints.todoapp.EventObserver
 import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.databinding.AddtaskFragBinding
@@ -37,6 +38,8 @@ import com.google.android.material.snackbar.Snackbar
 class AddEditTaskFragment : Fragment() {
 
     private lateinit var viewDataBinding: AddtaskFragBinding
+
+    private val args: AddEditTaskFragmentArgs by navArgs()
 
     private val viewModel by viewModels<AddEditTaskViewModel> { getVmFactory() }
 
@@ -56,7 +59,7 @@ class AddEditTaskFragment : Fragment() {
         setupSnackbar()
         setupNavigation()
         this.setupRefreshLayout(viewDataBinding.refreshLayout)
-        viewModel.start(getTaskId())
+        viewModel.start(args.taskId)
     }
 
     private fun setupSnackbar() {
@@ -71,11 +74,5 @@ class AddEditTaskFragment : Fragment() {
                 .actionAddEditTaskFragmentToTasksFragment(ADD_EDIT_RESULT_OK)
             findNavController().navigate(action)
         })
-    }
-
-    private fun getTaskId(): String? {
-        return arguments?.let {
-            AddEditTaskFragmentArgs.fromBundle(it).TASKID
-        }
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
@@ -27,6 +27,7 @@ import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.databinding.AddtaskFragBinding
 import com.example.android.architecture.blueprints.todoapp.util.ADD_EDIT_RESULT_OK
 import com.example.android.architecture.blueprints.todoapp.util.getVmFactory
+import com.example.android.architecture.blueprints.todoapp.util.setupRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.util.setupSnackbar
 import com.google.android.material.snackbar.Snackbar
 
@@ -54,7 +55,8 @@ class AddEditTaskFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
         setupSnackbar()
         setupNavigation()
-        loadData()
+        this.setupRefreshLayout(viewDataBinding.refreshLayout)
+        viewModel.start(getTaskId())
     }
 
     private fun setupSnackbar() {
@@ -69,11 +71,6 @@ class AddEditTaskFragment : Fragment() {
                 .actionAddEditTaskFragmentToTasksFragment(ADD_EDIT_RESULT_OK)
             findNavController().navigate(action)
         })
-    }
-
-    private fun loadData() {
-        // Add or edit an existing task?
-        viewDataBinding.viewmodel?.start(getTaskId())
     }
 
     private fun getTaskId(): String? {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -64,10 +64,10 @@ class AddEditTaskViewModel(
     private var taskCompleted = false
 
     fun start(taskId: String?) {
-        _dataLoading.value?.let { isLoading ->
-            // Already loading, ignore.
-            if (isLoading) return
+        if (_dataLoading.value == true) {
+            return
         }
+
         this.taskId = taskId
         if (taskId == null) {
             // No need to populate, it's a new task
@@ -78,6 +78,7 @@ class AddEditTaskViewModel(
             // No need to populate, already have data.
             return
         }
+
         isNewTask = false
         _dataLoading.value = true
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.viewModels
 import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.databinding.StatisticsFragBinding
 import com.example.android.architecture.blueprints.todoapp.util.getVmFactory
+import com.example.android.architecture.blueprints.todoapp.util.setupRefreshLayout
 
 /**
  * Main UI for the statistics screen.
@@ -46,10 +47,7 @@ class StatisticsFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
         viewDataBinding.stats = statisticsViewModel
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
-    }
-
-    override fun onResume() {
-        super.onResume()
+        this.setupRefreshLayout(viewDataBinding.refreshLayout)
         statisticsViewModel.start()
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
@@ -45,7 +45,7 @@ class StatisticsFragment : Fragment() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        viewDataBinding.stats = statisticsViewModel
+        viewDataBinding.viewmodel = statisticsViewModel
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
         this.setupRefreshLayout(viewDataBinding.refreshLayout)
         statisticsViewModel.start()

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
@@ -61,7 +61,14 @@ class StatisticsViewModel(
 
     private var completedTasks = 0
 
+    init {
+        start()
+    }
+
     fun start() {
+        if (_dataLoading.value == true) {
+            return
+        }
         _dataLoading.value = true
 
         wrapEspressoIdlingResource {
@@ -79,6 +86,10 @@ class StatisticsViewModel(
                 }
             }
         }
+    }
+
+    fun refresh() {
+        start()
     }
 
     /**

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
@@ -26,6 +26,7 @@ import android.widget.CheckBox
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.example.android.architecture.blueprints.todoapp.EventObserver
 import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.databinding.TaskdetailFragBinding
@@ -40,6 +41,8 @@ import com.google.android.material.snackbar.Snackbar
  */
 class TaskDetailFragment : Fragment() {
     private lateinit var viewDataBinding: TaskdetailFragBinding
+
+    private val args: TaskDetailFragmentArgs by navArgs()
 
     private val viewModel by viewModels<TaskDetailViewModel> { getVmFactory() }
 
@@ -61,9 +64,8 @@ class TaskDetailFragment : Fragment() {
             findNavController().navigate(action)
         })
         viewModel.editTaskCommand.observe(this, EventObserver {
-            val taskId = TaskDetailFragmentArgs.fromBundle(arguments!!).TASKID
             val action = TaskDetailFragmentDirections
-                .actionTaskDetailFragmentToAddEditTaskFragment(taskId,
+                .actionTaskDetailFragmentToAddEditTaskFragment(args.taskId,
                     resources.getString(R.string.edit_task))
             findNavController().navigate(action)
         })
@@ -91,10 +93,7 @@ class TaskDetailFragment : Fragment() {
         }
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
 
-        val taskId = arguments?.let {
-            TaskDetailFragmentArgs.fromBundle(it).TASKID
-        }
-        viewDataBinding.viewmodel?.start(taskId)
+        viewModel.start(args.taskId)
 
         setHasOptionsMenu(true)
         return view

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
@@ -31,6 +31,7 @@ import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.databinding.TaskdetailFragBinding
 import com.example.android.architecture.blueprints.todoapp.util.DELETE_RESULT_OK
 import com.example.android.architecture.blueprints.todoapp.util.getVmFactory
+import com.example.android.architecture.blueprints.todoapp.util.setupRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.util.setupSnackbar
 import com.google.android.material.snackbar.Snackbar
 
@@ -50,6 +51,7 @@ class TaskDetailFragment : Fragment() {
         }
 
         setupNavigation()
+        this.setupRefreshLayout(viewDataBinding.refreshLayout)
     }
 
     private fun setupNavigation() {
@@ -73,14 +75,6 @@ class TaskDetailFragment : Fragment() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        val taskId = arguments?.let {
-            TaskDetailFragmentArgs.fromBundle(it).TASKID
-        }
-        viewDataBinding.viewmodel?.start(taskId)
-    }
-
     override fun onCreateView(
             inflater: LayoutInflater,
             container: ViewGroup?,
@@ -95,7 +89,13 @@ class TaskDetailFragment : Fragment() {
                 }
             }
         }
-        viewDataBinding.setLifecycleOwner(this.viewLifecycleOwner)
+        viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
+
+        val taskId = arguments?.let {
+            TaskDetailFragmentArgs.fromBundle(it).TASKID
+        }
+        viewDataBinding.viewmodel?.start(taskId)
+
         setHasOptionsMenu(true)
         return view
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -87,7 +87,11 @@ class TaskDetailViewModel(
         }
     }
 
-    fun start(taskId: String?) {
+    fun start(taskId: String?, forceRefresh: Boolean = false) {
+        if (_isDataAvailable.value == true && !forceRefresh || _dataLoading.value == true) {
+            return
+        }
+
         // Show loading indicator
         _dataLoading.value = true
 
@@ -122,8 +126,8 @@ class TaskDetailViewModel(
         _isDataAvailable.value = false
     }
 
-    fun onRefresh() {
-        taskId?.let { start(it) }
+    fun refresh() {
+        taskId?.let { start(it, true) }
     }
 
     private fun showSnackbarMessage(@StringRes message: Int) {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -56,13 +56,14 @@ class TaskDetailViewModel(
     private val _snackbarText = MutableLiveData<Event<Int>>()
     val snackbarMessage: LiveData<Event<Int>> = _snackbarText
 
+    private val taskId: String?
+        get() = _task.value?.id
+
     // This LiveData depends on another so we can use a transformation.
     val completed: LiveData<Boolean> = Transformations.map(_task) { input: Task? ->
         input?.isCompleted ?: false
     }
 
-    val taskId: String?
-        get() = _task.value?.id
 
     fun deleteTask() = viewModelScope.launch {
         taskId?.let {
@@ -87,6 +88,7 @@ class TaskDetailViewModel(
     }
 
     fun start(taskId: String?) {
+        // Show loading indicator
         _dataLoading.value = true
 
         wrapEspressoIdlingResource {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -89,7 +89,6 @@ class TasksFragment : Fragment() {
         this.setupRefreshLayout(viewDataBinding.refreshLayout, viewDataBinding.tasksList)
         setupNavigation()
         setupFab()
-        viewDataBinding.viewmodel?.loadTasks(true)
     }
 
     private fun setupNavigation() {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -69,7 +69,7 @@ class TasksFragment : Fragment() {
                 true
             }
             R.id.menu_refresh -> {
-                viewDataBinding.viewmodel?.loadTasks(true)
+                viewModel.loadTasks(true)
                 true
             }
             else -> false
@@ -86,9 +86,13 @@ class TasksFragment : Fragment() {
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
         setupSnackbar()
         setupListAdapter()
-        this.setupRefreshLayout(viewDataBinding.refreshLayout, viewDataBinding.tasksList)
+        setupRefreshLayout(viewDataBinding.refreshLayout, viewDataBinding.tasksList)
         setupNavigation()
         setupFab()
+
+        // Always reloading data for simplicity. Real apps should only do this on first load and
+        // when navigating back to this destination. TODO: https://issuetracker.google.com/79672220
+        viewModel.loadTasks(true)
     }
 
     private fun setupNavigation() {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -24,7 +24,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -33,6 +32,7 @@ import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.databinding.TasksFragBinding
 import com.example.android.architecture.blueprints.todoapp.util.getVmFactory
+import com.example.android.architecture.blueprints.todoapp.util.setupRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.util.setupSnackbar
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
@@ -86,7 +86,7 @@ class TasksFragment : Fragment() {
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
         setupSnackbar()
         setupListAdapter()
-        setupRefreshLayout()
+        this.setupRefreshLayout(viewDataBinding.refreshLayout, viewDataBinding.tasksList)
         setupNavigation()
         setupFab()
         viewDataBinding.viewmodel?.loadTasks(true)
@@ -160,18 +160,6 @@ class TasksFragment : Fragment() {
             viewDataBinding.tasksList.adapter = listAdapter
         } else {
             Timber.w("ViewModel not initialized when attempting to set up adapter.")
-        }
-    }
-
-    private fun setupRefreshLayout() {
-        viewDataBinding.refreshLayout.run {
-            setColorSchemeColors(
-                    ContextCompat.getColor(requireActivity(), R.color.colorPrimary),
-                    ContextCompat.getColor(requireActivity(), R.color.colorAccent),
-                    ContextCompat.getColor(requireActivity(), R.color.colorPrimaryDark)
-            )
-            // Set the scrolling view in the custom SwipeRefreshLayout.
-            scrollUpChild = viewDataBinding.tasksList
         }
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -87,6 +87,7 @@ class TasksViewModel(
     init {
         // Set initial state
         setFiltering(TasksFilterType.ALL_TASKS)
+        loadTasks(true)
     }
 
     /**
@@ -180,7 +181,6 @@ class TasksViewModel(
      * @param showLoadingUI Pass in true to display a loading icon in the UI
      */
     fun loadTasks(forceUpdate: Boolean) {
-
         _dataLoading.value = true
 
         wrapEspressoIdlingResource {
@@ -215,5 +215,9 @@ class TasksViewModel(
                 _dataLoading.value = false
             }
         }
+    }
+
+    fun refresh() {
+        loadTasks(true)
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ViewExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ViewExt.kt
@@ -16,16 +16,19 @@
 package com.example.android.architecture.blueprints.todoapp.util
 
 /**
- * Extension functions for View and subclasses of View.
+ * Extension functions and Binding Adapters.
  */
 
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.Event
+import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.ScrollChildSwipeRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.tasks.TasksViewModel
 import com.google.android.material.snackbar.Snackbar
@@ -63,6 +66,22 @@ fun View.setupSnackbar(
         }
     })
 }
+
+fun Fragment.setupRefreshLayout(
+    refreshLayout: ScrollChildSwipeRefreshLayout,
+    scrollUpChild: View? = null
+) {
+    refreshLayout.setColorSchemeColors(
+        ContextCompat.getColor(requireActivity(), R.color.colorPrimary),
+        ContextCompat.getColor(requireActivity(), R.color.colorAccent),
+        ContextCompat.getColor(requireActivity(), R.color.colorPrimaryDark)
+    )
+    // Set the scrolling view in the custom SwipeRefreshLayout.
+    scrollUpChild?.let {
+        refreshLayout.scrollUpChild = it
+    }
+}
+
 
 /**
  * Reloads the data when the pull-to-refresh is triggered.

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ViewExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ViewExt.kt
@@ -21,16 +21,13 @@ package com.example.android.architecture.blueprints.todoapp.util
 
 import android.view.View
 import androidx.core.content.ContextCompat
-import androidx.databinding.BindingAdapter
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.android.architecture.blueprints.todoapp.Event
 import com.example.android.architecture.blueprints.todoapp.R
 import com.example.android.architecture.blueprints.todoapp.ScrollChildSwipeRefreshLayout
-import com.example.android.architecture.blueprints.todoapp.tasks.TasksViewModel
 import com.google.android.material.snackbar.Snackbar
 
 /**
@@ -80,16 +77,4 @@ fun Fragment.setupRefreshLayout(
     scrollUpChild?.let {
         refreshLayout.scrollUpChild = it
     }
-}
-
-
-/**
- * Reloads the data when the pull-to-refresh is triggered.
- *
- * Creates the `android:onRefresh` for a [SwipeRefreshLayout].
- */
-@BindingAdapter("android:onRefresh")
-fun ScrollChildSwipeRefreshLayout.setSwipeRefreshLayoutOnRefreshListener(
-        viewModel: TasksViewModel) {
-    setOnRefreshListener { viewModel.loadTasks(true) }
 }

--- a/app/src/main/res/layout/statistics_frag.xml
+++ b/app/src/main/res/layout/statistics_frag.xml
@@ -13,20 +13,22 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
 
         <import type="android.view.View"/>
 
         <variable
-            name="stats"
+            name="viewmodel"
             type="com.example.android.architecture.blueprints.todoapp.statistics.StatisticsViewModel"/>
     </data>
 
     <com.example.android.architecture.blueprints.todoapp.ScrollChildSwipeRefreshLayout
         android:id="@+id/refresh_layout"
-        app:refreshing="@{stats.dataLoading}"
+        app:refreshing="@{viewmodel.dataLoading}"
+        app:onRefreshListener="@{viewmodel::refresh}"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -44,23 +46,23 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical"
-                android:visibility="@{stats.dataLoading ? View.GONE : View.VISIBLE}">
+                android:visibility="@{viewmodel.dataLoading ? View.GONE : View.VISIBLE}">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/statistics_no_tasks"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:visibility="@{stats.empty ? View.VISIBLE : View.GONE}"/>
+                    android:visibility="@{viewmodel.empty ? View.VISIBLE : View.GONE}"/>
 
                 <TextView
                     android:id="@+id/stats_active_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingTop="1dp"
-                    android:text="@{@string/statistics_active_tasks(stats.activeTasksPercent)}"
+                    android:text="@{@string/statistics_active_tasks(viewmodel.activeTasksPercent)}"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}"/>
+                    android:visibility="@{viewmodel.empty ? View.GONE : View.VISIBLE}"/>
 
                 <!-- android:paddingTop specified to temporarily work around -->
                 <!-- https://github.com/robolectric/robolectric/issues/4588 -->
@@ -69,9 +71,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingTop="1dp"
-                    android:text="@{@string/statistics_completed_tasks(stats.completedTasksPercent)}"
+                    android:text="@{@string/statistics_completed_tasks(viewmodel.completedTasksPercent)}"
                     android:textAppearance="?android:attr/textAppearanceMedium"
-                    android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}"/>
+                    android:visibility="@{viewmodel.empty ? View.GONE : View.VISIBLE}"/>
 
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/statistics_frag.xml
+++ b/app/src/main/res/layout/statistics_frag.xml
@@ -17,63 +17,64 @@
 
     <data>
 
-        <import type="android.view.View" />
+        <import type="android.view.View"/>
 
         <variable
             name="stats"
-            type="com.example.android.architecture.blueprints.todoapp.statistics.StatisticsViewModel" />
+            type="com.example.android.architecture.blueprints.todoapp.statistics.StatisticsViewModel"/>
     </data>
 
-    <LinearLayout
+    <com.example.android.architecture.blueprints.todoapp.ScrollChildSwipeRefreshLayout
+        android:id="@+id/refresh_layout"
+        app:refreshing="@{stats.dataLoading}"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin">
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:text="@string/loading"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:visibility="@{stats.dataLoading ? View.VISIBLE : View.GONE}" />
+        android:layout_height="match_parent">
 
         <LinearLayout
-            android:id="@+id/statistics"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
-            android:visibility="@{stats.dataLoading ? View.GONE : View.VISIBLE}">
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingTop="@dimen/activity_vertical_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingBottom="@dimen/activity_vertical_margin">
 
-            <TextView
+            <LinearLayout
+                android:id="@+id/statistics"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/statistics_no_tasks"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:visibility="@{stats.empty ? View.VISIBLE : View.GONE}" />
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:visibility="@{stats.dataLoading ? View.GONE : View.VISIBLE}">
 
-            <TextView
-                android:id="@+id/stats_active_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="1dp"
-                android:text="@{@string/statistics_active_tasks(stats.activeTasksPercent)}"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/statistics_no_tasks"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:visibility="@{stats.empty ? View.VISIBLE : View.GONE}"/>
 
-            <!-- android:paddingTop specified to temporarily work around -->
-            <!-- https://github.com/robolectric/robolectric/issues/4588 -->
-            <TextView
-                android:id="@+id/stats_completed_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="1dp"
-                android:text="@{@string/statistics_completed_tasks(stats.completedTasksPercent)}"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}" />
+                <TextView
+                    android:id="@+id/stats_active_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="1dp"
+                    android:text="@{@string/statistics_active_tasks(stats.activeTasksPercent)}"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}"/>
 
+                <!-- android:paddingTop specified to temporarily work around -->
+                <!-- https://github.com/robolectric/robolectric/issues/4588 -->
+                <TextView
+                    android:id="@+id/stats_completed_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="1dp"
+                    android:text="@{@string/statistics_completed_tasks(stats.completedTasksPercent)}"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
+                    android:visibility="@{stats.empty ? View.GONE : View.VISIBLE}"/>
+
+            </LinearLayout>
         </LinearLayout>
-    </LinearLayout>
+
+    </com.example.android.architecture.blueprints.todoapp.ScrollChildSwipeRefreshLayout>
 </layout>

--- a/app/src/main/res/layout/taskdetail_frag.xml
+++ b/app/src/main/res/layout/taskdetail_frag.xml
@@ -39,7 +39,7 @@
             android:id="@+id/refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:onRefreshListener="@{viewmodel::onRefresh}"
+            app:onRefreshListener="@{viewmodel::refresh}"
             app:refreshing="@{viewmodel.dataLoading}">
 
             <LinearLayout

--- a/app/src/main/res/layout/taskdetail_frag.xml
+++ b/app/src/main/res/layout/taskdetail_frag.xml
@@ -65,7 +65,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/no_data"
-                        android:textAppearance="?android:attr/textAppearanceLarge"/>
+                        android:textAppearance="?android:attr/textAppearanceLarge"
+                        android:visibility="@{viewmodel.dataLoading ? View.GONE : View.VISIBLE}"/>
                 </LinearLayout>
 
                 <RelativeLayout
@@ -78,36 +79,36 @@
                     android:paddingBottom="@dimen/activity_vertical_margin"
                     android:visibility="@{viewmodel.isDataAvailable ? View.VISIBLE : View.GONE}">
 
-                <!-- android:paddingTop specified to temporarily work around -->
-                <!-- https://github.com/robolectric/robolectric/issues/4588 -->
-                <CheckBox
-                    android:id="@+id/task_detail_complete"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginRight="@dimen/activity_horizontal_margin"
-                    android:onClick="@{(view) -> listener.onCompleteChanged(view)}"
-                    android:paddingTop="1dp"
-                    android:checked="@{viewmodel.completed}" />
+                    <!-- android:paddingTop specified to temporarily work around -->
+                    <!-- https://github.com/robolectric/robolectric/issues/4588 -->
+                    <CheckBox
+                        android:id="@+id/task_detail_complete"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginRight="@dimen/activity_horizontal_margin"
+                        android:checked="@{viewmodel.completed}"
+                        android:onClick="@{(view) -> listener.onCompleteChanged(view)}"
+                        android:paddingTop="1dp"/>
 
-                <TextView
-                    android:id="@+id/task_detail_title"
-                    android:layout_toRightOf="@id/task_detail_complete"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingTop="1dp"
-                    android:text="@{viewmodel.task.title}"
-                    android:textAppearance="?android:attr/textAppearanceLarge" />
+                    <TextView
+                        android:id="@+id/task_detail_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_toRightOf="@id/task_detail_complete"
+                        android:paddingTop="1dp"
+                        android:text="@{viewmodel.task.title}"
+                        android:textAppearance="?android:attr/textAppearanceLarge"/>
 
-                <TextView
-                    android:id="@+id/task_detail_description"
-                    android:layout_toRightOf="@id/task_detail_complete"
-                    android:layout_below="@id/task_detail_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingTop="1dp"
-                    android:text="@{viewmodel.task.description}"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    <TextView
+                        android:id="@+id/task_detail_description"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@id/task_detail_title"
+                        android:layout_toRightOf="@id/task_detail_complete"
+                        android:paddingTop="1dp"
+                        android:text="@{viewmodel.task.description}"
+                        android:textAppearance="?android:attr/textAppearanceMedium"/>
 
                 </RelativeLayout>
             </LinearLayout>

--- a/app/src/main/res/layout/tasks_frag.xml
+++ b/app/src/main/res/layout/tasks_frag.xml
@@ -39,7 +39,7 @@
             android:id="@+id/refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:onRefresh="@{viewmodel}"
+            app:onRefreshListener="@{viewmodel::refresh}"
             app:refreshing="@{viewmodel.dataLoading}">
 
             <RelativeLayout

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -28,7 +28,7 @@
             android:id="@+id/action_taskDetailFragment_to_addEditTaskFragment"
             app:destination="@id/addEditTaskFragment" />
         <argument
-            android:name="TASK_ID"
+            android:name="taskId"
             app:argType="string" />
         <action
             android:id="@+id/action_taskDetailFragment_to_tasksFragment"
@@ -66,7 +66,7 @@
         android:name="com.example.android.architecture.blueprints.todoapp.addedittask.AddEditTaskFragment"
         android:label="{title}" >
         <argument
-            android:name="TASK_ID"
+            android:name="taskId"
             app:argType="string"
             app:nullable="true"/>
         <argument

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsUtilsTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsUtilsTest.kt
@@ -19,7 +19,6 @@ package com.example.android.architecture.blueprints.todoapp.statistics
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import org.hamcrest.core.Is.`is`
 import org.junit.Assert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -72,7 +71,6 @@ class StatisticsUtilsTest {
     }
 
     @Test
-    @Ignore
     fun getActiveAndCompletedStats_error() {
         // When there's an error loading stats
         val result = getActiveAndCompletedStats(null)
@@ -83,7 +81,6 @@ class StatisticsUtilsTest {
     }
 
     @Test
-    @Ignore
     fun getActiveAndCompletedStats_empty() {
         // When there are no tasks
         val result = getActiveAndCompletedStats(emptyList())

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsUtilsTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsUtilsTest.kt
@@ -19,6 +19,7 @@ package com.example.android.architecture.blueprints.todoapp.statistics
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import org.hamcrest.core.Is.`is`
 import org.junit.Assert.assertThat
+import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -71,6 +72,7 @@ class StatisticsUtilsTest {
     }
 
     @Test
+    @Ignore
     fun getActiveAndCompletedStats_error() {
         // When there's an error loading stats
         val result = getActiveAndCompletedStats(null)
@@ -81,6 +83,7 @@ class StatisticsUtilsTest {
     }
 
     @Test
+    @Ignore
     fun getActiveAndCompletedStats_empty() {
         // When there are no tasks
         val result = getActiveAndCompletedStats(emptyList())


### PR DESCRIPTION
No duplicate loads in ViewModels anymore
Also fixes the ScrollChildSwipeRefreshLayout. Now it's correctly implemented in all 4 fragments.