### PR TITLE
Checking getOrAwaitValue removal

### DIFF
--- a/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
+++ b/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
@@ -93,6 +93,7 @@ class FakeRepository : TasksRepository {
     override suspend fun completeTask(task: Task) {
         val completedTask = Task(task.title, task.description, true, task.id)
         tasksServiceData[task.id] = completedTask
+        refreshTasks()
     }
 
     override suspend fun completeTask(taskId: String) {
@@ -103,6 +104,7 @@ class FakeRepository : TasksRepository {
     override suspend fun activateTask(task: Task) {
         val activeTask = Task(task.title, task.description, false, task.id)
         tasksServiceData[task.id] = activeTask
+        refreshTasks()
     }
 
     override suspend fun activateTask(taskId: String) {

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/TestUtil.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/TestUtil.kt
@@ -23,11 +23,11 @@ fun assertLiveDataEventTriggered(
     liveData: LiveData<Event<String>>,
     taskId: String
 ) {
-    val value = liveData.getOrAwaitValue()
-    assertEquals(value.getContentIfNotHandled(), taskId)
+    val value = liveData.value
+    assertEquals(value?.getContentIfNotHandled(), taskId)
 }
 
 fun assertSnackbarMessage(snackbarLiveData: LiveData<Event<Int>>, messageId: Int) {
-    val value: Event<Int> = snackbarLiveData.getOrAwaitValue()
-    assertEquals(value.getContentIfNotHandled(), messageId)
+    val value = snackbarLiveData.value
+    assertEquals(value?.getContentIfNotHandled(), messageId)
 }

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.kt
@@ -21,7 +21,6 @@ import com.example.android.architecture.blueprints.todoapp.R.string
 import com.example.android.architecture.blueprints.todoapp.assertSnackbarMessage
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.FakeRepository
-import com.example.android.architecture.blueprints.todoapp.getOrAwaitValue
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
@@ -86,13 +85,13 @@ class AddEditTaskViewModelTest {
         addEditTaskViewModel.start(task.id)
 
         // Then progress indicator is shown
-        assertThat(addEditTaskViewModel.dataLoading.getOrAwaitValue()).isTrue()
+        assertThat(addEditTaskViewModel.dataLoading.value).isTrue()
 
         // Execute pending coroutines actions
         mainCoroutineRule.resumeDispatcher()
 
         // Then progress indicator is hidden
-        assertThat(addEditTaskViewModel.dataLoading.getOrAwaitValue()).isFalse()
+        assertThat(addEditTaskViewModel.dataLoading.value).isFalse()
     }
 
     @Test
@@ -104,9 +103,9 @@ class AddEditTaskViewModelTest {
         addEditTaskViewModel.start(task.id)
 
         // Verify a task is loaded
-        assertThat(addEditTaskViewModel.title.getOrAwaitValue()).isEqualTo(task.title)
-        assertThat(addEditTaskViewModel.description.getOrAwaitValue()).isEqualTo(task.description)
-        assertThat(addEditTaskViewModel.dataLoading.getOrAwaitValue()).isFalse()
+        assertThat(addEditTaskViewModel.title.value).isEqualTo(task.title)
+        assertThat(addEditTaskViewModel.description.value).isEqualTo(task.description)
+        assertThat(addEditTaskViewModel.dataLoading.value).isFalse()
     }
 
     @Test

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModelTest.kt
@@ -21,7 +21,7 @@ import com.example.android.architecture.blueprints.todoapp.MainCoroutineRule
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.DefaultTasksRepository
 import com.example.android.architecture.blueprints.todoapp.data.source.FakeRepository
-import com.example.android.architecture.blueprints.todoapp.getOrAwaitValue
+import com.example.android.architecture.blueprints.todoapp.observeForTesting
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -60,8 +60,10 @@ class StatisticsViewModelTest {
     fun loadEmptyTasksFromRepository_EmptyResults() = mainCoroutineRule.runBlockingTest {
         // Given an initialized StatisticsViewModel with no tasks
 
-        // Then the results are empty
-        assertThat(statisticsViewModel.empty.getOrAwaitValue()).isTrue()
+        statisticsViewModel.empty.observeForTesting {
+            // Then the results are empty
+            assertThat(statisticsViewModel.empty.value).isTrue()
+        }
     }
 
     @Test
@@ -73,13 +75,20 @@ class StatisticsViewModelTest {
         val task4 = Task("Title4", "Description4", true)
         tasksRepository.addTasks(task1, task2, task3, task4)
 
+
         // Then the results are not empty
-        assertThat(statisticsViewModel.empty.getOrAwaitValue())
-            .isFalse()
-        assertThat(statisticsViewModel.activeTasksPercent.getOrAwaitValue())
-            .isEqualTo(25f)
-        assertThat(statisticsViewModel.completedTasksPercent.getOrAwaitValue())
-            .isEqualTo(75f)
+        statisticsViewModel.empty.observeForTesting {
+            assertThat(statisticsViewModel.empty.value)
+                .isFalse()
+        }
+        statisticsViewModel.activeTasksPercent.observeForTesting {
+            assertThat(statisticsViewModel.activeTasksPercent.value)
+                .isEqualTo(25f)
+        }
+        statisticsViewModel.completedTasksPercent.observeForTesting {
+            assertThat(statisticsViewModel.completedTasksPercent.value)
+                .isEqualTo(75f)
+        }
     }
 
     @Test
@@ -93,8 +102,13 @@ class StatisticsViewModelTest {
         )
 
         // Then an error message is shown
-        assertThat(errorViewModel.empty.getOrAwaitValue()).isTrue()
-        assertThat(errorViewModel.error.getOrAwaitValue()).isTrue()
+        errorViewModel.empty.observeForTesting {
+            assertThat(errorViewModel.empty.value).isTrue()
+        }
+
+        errorViewModel.error.observeForTesting {
+            assertThat(errorViewModel.error.value).isTrue()
+        }
     }
 
     @Test
@@ -106,12 +120,12 @@ class StatisticsViewModelTest {
         statisticsViewModel.refresh()
 
         // Then progress indicator is shown
-        assertThat(statisticsViewModel.dataLoading.getOrAwaitValue()).isTrue()
+        assertThat(statisticsViewModel.dataLoading.value).isTrue()
 
         // Execute pending coroutines actions
         mainCoroutineRule.resumeDispatcher()
 
         // Then progress indicator is hidden
-        assertThat(statisticsViewModel.dataLoading.getOrAwaitValue()).isFalse()
+        assertThat(statisticsViewModel.dataLoading.value).isFalse()
     }
 }

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModelTest.kt
@@ -23,7 +23,6 @@ import com.example.android.architecture.blueprints.todoapp.assertLiveDataEventTr
 import com.example.android.architecture.blueprints.todoapp.assertSnackbarMessage
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.FakeRepository
-import com.example.android.architecture.blueprints.todoapp.getOrAwaitValue
 import com.example.android.architecture.blueprints.todoapp.observeForTesting
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -80,16 +79,16 @@ class TasksViewModelTest {
         tasksViewModel.items.observeForTesting {
 
             // Then progress indicator is shown
-            assertThat(tasksViewModel.dataLoading.getOrAwaitValue()).isTrue()
+            assertThat(tasksViewModel.dataLoading.value).isTrue()
 
             // Execute pending coroutines actions
             mainCoroutineRule.resumeDispatcher()
 
             // Then progress indicator is hidden
-            assertThat(tasksViewModel.dataLoading.getOrAwaitValue()).isFalse()
+            assertThat(tasksViewModel.dataLoading.value).isFalse()
 
             // And data correctly loaded
-            assertThat(tasksViewModel.items.getOrAwaitValue()).hasSize(3)
+            assertThat(tasksViewModel.items.value).hasSize(3)
         }
     }
 
@@ -105,10 +104,10 @@ class TasksViewModelTest {
         tasksViewModel.items.observeForTesting {
 
             // Then progress indicator is hidden
-            assertThat(tasksViewModel.dataLoading.getOrAwaitValue()).isFalse()
+            assertThat(tasksViewModel.dataLoading.value).isFalse()
 
             // And data correctly loaded
-            assertThat(tasksViewModel.items.getOrAwaitValue()).hasSize(1)
+            assertThat(tasksViewModel.items.value).hasSize(1)
         }
     }
 
@@ -124,10 +123,10 @@ class TasksViewModelTest {
         tasksViewModel.items.observeForTesting {
 
             // Then progress indicator is hidden
-            assertThat(tasksViewModel.dataLoading.getOrAwaitValue()).isFalse()
+            assertThat(tasksViewModel.dataLoading.value).isFalse()
 
             // And data correctly loaded
-            assertThat(tasksViewModel.items.getOrAwaitValue()).hasSize(2)
+            assertThat(tasksViewModel.items.value).hasSize(2)
         }
     }
 
@@ -142,10 +141,10 @@ class TasksViewModelTest {
         tasksViewModel.items.observeForTesting {
 
             // Then progress indicator is hidden
-            assertThat(tasksViewModel.dataLoading.getOrAwaitValue()).isFalse()
+            assertThat(tasksViewModel.dataLoading.value).isFalse()
 
             // And the list of items is empty
-            assertThat(tasksViewModel.items.getOrAwaitValue()).isEmpty()
+            assertThat(tasksViewModel.items.value).isEmpty()
 
             // And the snackbar updated
             assertSnackbarMessage(tasksViewModel.snackbarText, R.string.loading_tasks_error)
@@ -158,8 +157,8 @@ class TasksViewModelTest {
         tasksViewModel.addNewTask()
 
         // Then the event is triggered
-        val value = tasksViewModel.newTaskEvent.getOrAwaitValue()
-        assertThat(value.getContentIfNotHandled()).isNotNull()
+        val value = tasksViewModel.newTaskEvent.value
+        assertThat(value?.getContentIfNotHandled()).isNotNull()
     }
 
     @Test
@@ -180,20 +179,24 @@ class TasksViewModelTest {
         // Fetch tasks
         tasksViewModel.loadTasks(true)
 
-        // Fetch tasks
-        val allTasks = tasksViewModel.items.getOrAwaitValue()
-        val completedTasks = allTasks.filter { it.isCompleted }
 
-        // Verify there are no completed tasks left
-        assertThat(completedTasks).isEmpty()
+        tasksViewModel.items.observeForTesting {
 
-        // Verify active task is not cleared
-        assertThat(allTasks).hasSize(1)
+            // Fetch tasks
+            val allTasks = tasksViewModel.items.value
+            val completedTasks = allTasks?.filter { it.isCompleted }
 
-        // Verify snackbar is updated
-        assertSnackbarMessage(
-            tasksViewModel.snackbarText, R.string.completed_tasks_cleared
-        )
+            // Verify there are no completed tasks left
+            assertThat(completedTasks).isEmpty()
+
+            // Verify active task is not cleared
+            assertThat(allTasks).hasSize(1)
+
+            // Verify snackbar is updated
+            assertSnackbarMessage(
+                tasksViewModel.snackbarText, R.string.completed_tasks_cleared
+            )
+        }
     }
 
     @Test
@@ -269,6 +272,6 @@ class TasksViewModelTest {
         tasksViewModel.setFiltering(TasksFilterType.ALL_TASKS)
 
         // Then the "Add task" action is visible
-        assertThat(tasksViewModel.tasksAddViewVisible.getOrAwaitValue()).isTrue()
+        assertThat(tasksViewModel.tasksAddViewVisible.value).isTrue()
     }
 }


### PR DESCRIPTION
All of these tests pass and are using only `observeForTesting` (ran them 100 times each) - when should one decide to use `observeForTesting` versus `getOrAwaitValue()`?

Also can you review the tests in TaskDetailViewModelTest? FakeRepository wasn't updating the task LiveData on complete/activateTask; it now updates the whole task list - not sure this is proper behavior, but it does make the completed LiveData update as expected.